### PR TITLE
adapt lazy loading to work with async

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,11 +75,10 @@ repos:
         additional_dependencies: [
             'celery==5.4.0',
             'git+https://github.com/RUBclim/element-api@0.1.1',
-            'fastapi==0.115.4',
-            'sqlalchemy[mypy]==2.0.36',
-            'psycopg[binary]==3.2.3',
-            'alembic==1.13.3',
-            'pandas-stubs==2.2.3.241009',
-            'sqlmodel==0.0.22',
-            'pythermalcomfort==3.0.0'
+            'fastapi==0.115.11',
+            'sqlalchemy[mypy]==2.0.39',
+            'psycopg[binary]==3.2.6',
+            'alembic==1.15.1',
+            'pandas-stubs==2.2.3.250308',
+            'sqlmodel==0.0.24',
         ]

--- a/app/database.py
+++ b/app/database.py
@@ -5,13 +5,14 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncAttrs
 from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
 
-class Base(DeclarativeBase):
+class Base(AsyncAttrs, DeclarativeBase):
     pass
 
 

--- a/app/routers/v1.py
+++ b/app/routers/v1.py
@@ -314,7 +314,6 @@ async def get_trends(
 
     # we need to to do this completely different depending on whether stations or
     # districts are requested
-    query: Select[Any] | CompoundSelect
     if spatial_level == 'stations':
         # get the supported ids which are needed for the API return, probably for
         # possible comparison
@@ -785,7 +784,7 @@ async def get_network_snapshot(
     columns_temp_rh: list[InstrumentedAttribute[Any] | None] = [
         getattr(tempr_rh_table, i, None) for i in param
     ]
-    query: Select[Any] | CompoundSelect
+    query: Select[Any] | CompoundSelect[Any]
     query = select(
         biomet_table.measured_at,
         biomet_table.station_id,


### PR DESCRIPTION
previously most queries were loaded regardless of the attribute access. Even when explicitly made lazy, they would cause a greenlet error. This should slightly speed up everyting database-related.