### PR TITLE
all dependencies now have wheels and are available on pypi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ RUN : \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         wait-for-it \
-        # TODO: once we have wheels on PyPi for these, we can remove this
-        gfortran \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/requirements.in
+++ b/requirements.in
@@ -2,8 +2,8 @@ alembic
 asgiref
 celery[redis]
 fastapi
-git+https://github.com/RUBclim/element-api@1.0.0
-git+https://github.com/RUBclim/thermal-comfort@0.3.3
+element-iot-api
+thermal-comfort
 gunicorn
 psycopg[binary] > 3.2.0
 psycopg2-binary

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ click-repl==0.3.0
 click-spinner==0.1.10
 cligj==0.7.2
 color-operations==0.2.0
-element-api @ git+https://github.com/RUBclim/element-api@1e6af4b10bebee2ba11f4685fed4aa7807b8635f
+element-iot-api==1.0.1
 fastapi==0.115.12
 flask==3.1.0
 flask-cors==5.0.1
@@ -61,7 +61,7 @@ sqlalchemy==2.0.40
 sqlmodel==0.0.24
 starlette==0.46.2
 terracotta==0.9.1
-thermal-comfort @ git+https://github.com/RUBclim/thermal-comfort@f1a69e1914ec773228380b0abad4afbafab6d520
+thermal-comfort==1.1.0
 toml==0.10.2
 tqdm==4.67.1
 typing-extensions==4.13.2


### PR DESCRIPTION
we don't need to have gfortran now