### PR TITLE
make periodic tasks expire

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -65,16 +65,19 @@ def setup_periodic_tasks(
         crontab(minute='*/5'),
         _sync_data_wrapper.s(),
         name='download-data-periodic',
+        expires=timedelta(minutes=5),
     )
     sender.add_periodic_task(
         crontab(minute='2', hour='*/1'),
         check_for_new_sensors.s(),
         name='check-new-sensors-periodic',
+        expires=timedelta(minutes=45),
     )
     sender.add_periodic_task(
         crontab(minute='2', hour='1'),
         self_test_integrity.s(),
         name='self_test_integrity',
+        expires=timedelta(minutes=45),
     )
 
 


### PR DESCRIPTION
this prevents the queue piling up with tasks creating tasks over time when the workers are not available or busy