### PR TITLE
expose buddy check QC flags via the public API

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -115,6 +115,10 @@ class PublicParamsTempRH(StrEnum):
     relative_humidity_qc_persistence_check = 'relative_humidity_qc_persistence_check'
     relative_humidity_qc_spike_dip_check = 'relative_humidity_qc_spike_dip_check'
     qc_flagged = 'qc_flagged'
+    air_temperature_qc_isolated_check = 'air_temperature_qc_isolated_check'
+    air_temperature_qc_buddy_check = 'air_temperature_qc_buddy_check'
+    relative_humidity_qc_isolated_check = 'relative_humidity_qc_isolated_check'
+    relative_humidity_qc_buddy_check = 'relative_humidity_qc_buddy_check'
 
 
 class PublicParamsBiomet(StrEnum):
@@ -173,6 +177,12 @@ class PublicParamsBiomet(StrEnum):
     wind_speed_qc_range_check = 'wind_speed_qc_range_check'
     wind_speed_qc_spike_dip_check = 'wind_speed_qc_spike_dip_check'
     qc_flagged = 'qc_flagged'
+    air_temperature_qc_isolated_check = 'air_temperature_qc_isolated_check'
+    air_temperature_qc_buddy_check = 'air_temperature_qc_buddy_check'
+    relative_humidity_qc_isolated_check = 'relative_humidity_qc_isolated_check'
+    relative_humidity_qc_buddy_check = 'relative_humidity_qc_buddy_check'
+    atmospheric_pressure_qc_isolated_check = 'atmospheric_pressure_qc_isolated_check'
+    atmospheric_pressure_qc_buddy_check = 'atmospheric_pressure_qc_buddy_check'
 
 
 class PublicParamsAggTempRH(StrEnum):
@@ -371,6 +381,13 @@ class PublicParams(StrEnum):
     wind_speed_qc_spike_dip_check = 'wind_speed_qc_spike_dip_check'
     # qc flag considering all
     qc_flagged = 'qc_flagged'
+    # buddy check qc flags
+    air_temperature_qc_isolated_check = 'air_temperature_qc_isolated_check'
+    air_temperature_qc_buddy_check = 'air_temperature_qc_buddy_check'
+    relative_humidity_qc_isolated_check = 'relative_humidity_qc_isolated_check'
+    relative_humidity_qc_buddy_check = 'relative_humidity_qc_buddy_check'
+    atmospheric_pressure_qc_isolated_check = 'atmospheric_pressure_qc_isolated_check'
+    atmospheric_pressure_qc_buddy_check = 'atmospheric_pressure_qc_buddy_check'
 
 
 class ParamSettings(NamedTuple):
@@ -1073,6 +1090,42 @@ class QCFlags(BaseModel):
     )
 
 
+class BuddyCheckQCFlags(BaseModel):
+    air_temperature_qc_isolated_check: bool | None = Field(
+        None,
+        examples=[True],
+        description='quality control for the air temperature using an isolation check',
+    )
+    air_temperature_qc_buddy_check: bool | None = Field(
+        None,
+        examples=[True],
+        description='quality control for the air temperature using a buddy check',
+    )
+    relative_humidity_qc_isolated_check: bool | None = Field(
+        None,
+        examples=[True],
+        description=(
+            'quality control for the relative humidity using an isolation check'
+        ),
+    )
+    relative_humidity_qc_buddy_check: bool | None = Field(
+        None,
+        examples=[True],
+        description='quality control for the relative humidity using a buddy check',
+    )
+    atmospheric_pressure_qc_isolated_check: bool | None = Field(
+        None,
+        examples=[True],
+        description=(
+            'quality control for the atmospheric pressure using an isolation check'
+        ),
+    )
+    atmospheric_pressure_qc_buddy_check: bool | None = Field(
+        None,
+        examples=[True],
+        description='quality control for the atmospheric pressure using a buddy check',
+    )
+
 # TODO: we may also generate these at some point from either the enums or the basic
 # schema without extreme values
 
@@ -1271,7 +1324,7 @@ class DistrictParams(Parameters):
     )
 
 
-class StationData(Parameters, QCFlags):
+class StationData(Parameters, QCFlags, BuddyCheckQCFlags):
     """Data from a single station"""
     measured_at: datetime = Field(
         examples=[datetime(2024, 8, 28, 18, 50, 13, 169)],

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2115,6 +2115,7 @@ async def test_get_data_biomet_max_qc_flag(
                 'maximum_wind_speed_qc_range_check',
                 'relative_humidity',
                 'relative_humidity_qc_range_check',
+                'relative_humidity_qc_buddy_check',
                 'qc_flagged',
             ],
             'scale': 'max',
@@ -2129,6 +2130,7 @@ async def test_get_data_biomet_max_qc_flag(
             'qc_flagged': True,
             'relative_humidity_qc_range_check': None,
             'maximum_wind_speed_qc_range_check': None,
+            'relative_humidity_qc_buddy_check': None,
         },
         {
             'measured_at': '2024-08-01T12:10:00Z',
@@ -2137,6 +2139,7 @@ async def test_get_data_biomet_max_qc_flag(
             'qc_flagged': True,
             'relative_humidity_qc_range_check': None,
             'maximum_wind_speed_qc_range_check': None,
+            'relative_humidity_qc_buddy_check': None,
         },
     ]
 
@@ -2583,7 +2586,16 @@ async def test_get_temp_rh_data_scale_hourly_multiple_params(
 
 @pytest.mark.anyio
 @pytest.mark.usefixtures('clean_db')
+@pytest.mark.parametrize(
+    'unknown_param',
+    (
+        'relative_humidity_max',
+        'atmospheric_pressure_qc_isolated_check',
+        'atmospheric_pressure_qc_buddy_check',
+    ),
+)
 async def test_get_temp_rh_data_scale_max_param_not_found(
+        unknown_param: str,
         app: AsyncClient,
         db: AsyncSession,
 ) -> None:
@@ -2610,7 +2622,7 @@ async def test_get_temp_rh_data_scale_max_param_not_found(
             'start_date': datetime(2024, 8, 1, 10, 0).isoformat(),
             'end_date': datetime(2024, 8, 1, 11, 0).isoformat(),
             # this is a valid param, however not available with scale max
-            'param': ['air_temperature', 'relative_humidity_max'],
+            'param': ['air_temperature', unknown_param],
             'scale': 'max',
         },
     )
@@ -2621,25 +2633,32 @@ async def test_get_temp_rh_data_scale_max_param_not_found(
                 'ctx': {
                     'expected': (
                         'absolute_humidity, air_temperature, '
+                        'air_temperature_qc_buddy_check, '
+                        'air_temperature_qc_isolated_check, '
                         'air_temperature_qc_persistence_check, '
                         'air_temperature_qc_range_check, '
                         'air_temperature_qc_spike_dip_check, dew_point, heat_index, '
                         'qc_flagged, relative_humidity, '
+                        'relative_humidity_qc_buddy_check, '
+                        'relative_humidity_qc_isolated_check, '
                         'relative_humidity_qc_persistence_check, '
                         'relative_humidity_qc_range_check, '
                         'relative_humidity_qc_spike_dip_check, specific_humidity, '
                         'wet_bulb_temperature'
                     ),
                 },
-                'input': 'relative_humidity_max',
+                'input': unknown_param,
                 'loc': ['query', 'param', 1],
                 'msg': (
                     'This station is of type "temprh", hence the input should be: '
                     'absolute_humidity, air_temperature, '
+                    'air_temperature_qc_buddy_check, '
+                    'air_temperature_qc_isolated_check, '
                     'air_temperature_qc_persistence_check, '
                     'air_temperature_qc_range_check, '
                     'air_temperature_qc_spike_dip_check, dew_point, heat_index, '
-                    'qc_flagged, relative_humidity, '
+                    'qc_flagged, relative_humidity, relative_humidity_qc_buddy_check, '
+                    'relative_humidity_qc_isolated_check, '
                     'relative_humidity_qc_persistence_check, '
                     'relative_humidity_qc_range_check, '
                     'relative_humidity_qc_spike_dip_check, specific_humidity, '
@@ -3359,7 +3378,7 @@ async def test_download_station_no_data_for_station(
 
     assert len(csv_file) == 1
     # header correct
-    assert csv_file[0] == 'station_id,measured_at,absolute_humidity,air_temperature,air_temperature_qc_persistence_check,air_temperature_qc_range_check,air_temperature_qc_spike_dip_check,atmospheric_pressure,atmospheric_pressure_qc_persistence_check,atmospheric_pressure_qc_range_check,atmospheric_pressure_qc_spike_dip_check,atmospheric_pressure_reduced,dew_point,heat_index,lightning_average_distance,lightning_average_distance_qc_persistence_check,lightning_average_distance_qc_range_check,lightning_strike_count,lightning_strike_count_qc_persistence_check,lightning_strike_count_qc_range_check,maximum_wind_speed,maximum_wind_speed_qc_persistence_check,maximum_wind_speed_qc_range_check,mrt,pet,pet_category,precipitation_sum,precipitation_sum_qc_persistence_check,precipitation_sum_qc_range_check,precipitation_sum_qc_spike_dip_check,relative_humidity,relative_humidity_qc_persistence_check,relative_humidity_qc_range_check,relative_humidity_qc_spike_dip_check,solar_radiation,solar_radiation_qc_persistence_check,solar_radiation_qc_range_check,solar_radiation_qc_spike_dip_check,specific_humidity,utci,utci_category,vapor_pressure,wet_bulb_temperature,wind_direction,wind_direction_qc_persistence_check,wind_direction_qc_range_check,wind_speed,wind_speed_qc_persistence_check,wind_speed_qc_range_check,wind_speed_qc_spike_dip_check,qc_flagged'  # noqa: E501
+    assert csv_file[0] == 'station_id,measured_at,absolute_humidity,air_temperature,air_temperature_qc_buddy_check,air_temperature_qc_isolated_check,air_temperature_qc_persistence_check,air_temperature_qc_range_check,air_temperature_qc_spike_dip_check,atmospheric_pressure,atmospheric_pressure_qc_buddy_check,atmospheric_pressure_qc_isolated_check,atmospheric_pressure_qc_persistence_check,atmospheric_pressure_qc_range_check,atmospheric_pressure_qc_spike_dip_check,atmospheric_pressure_reduced,dew_point,heat_index,lightning_average_distance,lightning_average_distance_qc_persistence_check,lightning_average_distance_qc_range_check,lightning_strike_count,lightning_strike_count_qc_persistence_check,lightning_strike_count_qc_range_check,maximum_wind_speed,maximum_wind_speed_qc_persistence_check,maximum_wind_speed_qc_range_check,mrt,pet,pet_category,precipitation_sum,precipitation_sum_qc_persistence_check,precipitation_sum_qc_range_check,precipitation_sum_qc_spike_dip_check,relative_humidity,relative_humidity_qc_buddy_check,relative_humidity_qc_isolated_check,relative_humidity_qc_persistence_check,relative_humidity_qc_range_check,relative_humidity_qc_spike_dip_check,solar_radiation,solar_radiation_qc_persistence_check,solar_radiation_qc_range_check,solar_radiation_qc_spike_dip_check,specific_humidity,utci,utci_category,vapor_pressure,wet_bulb_temperature,wind_direction,wind_direction_qc_persistence_check,wind_direction_qc_range_check,wind_speed,wind_speed_qc_persistence_check,wind_speed_qc_range_check,wind_speed_qc_spike_dip_check,qc_flagged'  # noqa: E501
 
 
 @pytest.mark.anyio
@@ -3380,9 +3399,9 @@ async def test_download_station_data_no_dates_set(
     # 11 data points + 1 header
     assert len(csv_file) == 12
     # header correct
-    assert csv_file[0] == 'station_id,measured_at,absolute_humidity,air_temperature,air_temperature_qc_persistence_check,air_temperature_qc_range_check,air_temperature_qc_spike_dip_check,atmospheric_pressure,atmospheric_pressure_qc_persistence_check,atmospheric_pressure_qc_range_check,atmospheric_pressure_qc_spike_dip_check,atmospheric_pressure_reduced,dew_point,heat_index,lightning_average_distance,lightning_average_distance_qc_persistence_check,lightning_average_distance_qc_range_check,lightning_strike_count,lightning_strike_count_qc_persistence_check,lightning_strike_count_qc_range_check,maximum_wind_speed,maximum_wind_speed_qc_persistence_check,maximum_wind_speed_qc_range_check,mrt,pet,pet_category,precipitation_sum,precipitation_sum_qc_persistence_check,precipitation_sum_qc_range_check,precipitation_sum_qc_spike_dip_check,relative_humidity,relative_humidity_qc_persistence_check,relative_humidity_qc_range_check,relative_humidity_qc_spike_dip_check,solar_radiation,solar_radiation_qc_persistence_check,solar_radiation_qc_range_check,solar_radiation_qc_spike_dip_check,specific_humidity,utci,utci_category,vapor_pressure,wet_bulb_temperature,wind_direction,wind_direction_qc_persistence_check,wind_direction_qc_range_check,wind_speed,wind_speed_qc_persistence_check,wind_speed_qc_range_check,wind_speed_qc_spike_dip_check,qc_flagged'  # noqa: E501
-    assert csv_file[1] == 'DOB1,2024-08-01 00:00:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
-    assert csv_file[-1] == 'DOB1,2024-08-01 00:50:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
+    assert csv_file[0] == 'station_id,measured_at,absolute_humidity,air_temperature,air_temperature_qc_buddy_check,air_temperature_qc_isolated_check,air_temperature_qc_persistence_check,air_temperature_qc_range_check,air_temperature_qc_spike_dip_check,atmospheric_pressure,atmospheric_pressure_qc_buddy_check,atmospheric_pressure_qc_isolated_check,atmospheric_pressure_qc_persistence_check,atmospheric_pressure_qc_range_check,atmospheric_pressure_qc_spike_dip_check,atmospheric_pressure_reduced,dew_point,heat_index,lightning_average_distance,lightning_average_distance_qc_persistence_check,lightning_average_distance_qc_range_check,lightning_strike_count,lightning_strike_count_qc_persistence_check,lightning_strike_count_qc_range_check,maximum_wind_speed,maximum_wind_speed_qc_persistence_check,maximum_wind_speed_qc_range_check,mrt,pet,pet_category,precipitation_sum,precipitation_sum_qc_persistence_check,precipitation_sum_qc_range_check,precipitation_sum_qc_spike_dip_check,relative_humidity,relative_humidity_qc_buddy_check,relative_humidity_qc_isolated_check,relative_humidity_qc_persistence_check,relative_humidity_qc_range_check,relative_humidity_qc_spike_dip_check,solar_radiation,solar_radiation_qc_persistence_check,solar_radiation_qc_range_check,solar_radiation_qc_spike_dip_check,specific_humidity,utci,utci_category,vapor_pressure,wet_bulb_temperature,wind_direction,wind_direction_qc_persistence_check,wind_direction_qc_range_check,wind_speed,wind_speed_qc_persistence_check,wind_speed_qc_range_check,wind_speed_qc_spike_dip_check,qc_flagged'  # noqa: E501
+    assert csv_file[1] == 'DOB1,2024-08-01 00:00:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
+    assert csv_file[-1] == 'DOB1,2024-08-01 00:50:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
 
 
 @pytest.mark.anyio
@@ -3408,8 +3427,8 @@ async def test_download_station_data_only_start_date_set(
 
     # 11 data points + 1 header
     assert len(csv_file) == 6
-    assert csv_file[1] == 'DOB1,2024-08-01 00:30:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
-    assert csv_file[-1] == 'DOB1,2024-08-01 00:50:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
+    assert csv_file[1] == 'DOB1,2024-08-01 00:30:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
+    assert csv_file[-1] == 'DOB1,2024-08-01 00:50:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
 
 
 @pytest.mark.anyio
@@ -3435,8 +3454,8 @@ async def test_download_station_data_only_end_date_set(
 
     # 11 data points + 1 header, a bunch of qc flags, and the final qc flag
     assert len(csv_file) == 8
-    assert csv_file[1] == 'DOB1,2024-08-01 00:00:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
-    assert csv_file[-1] == 'DOB1,2024-08-01 00:30:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
+    assert csv_file[1] == 'DOB1,2024-08-01 00:00:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
+    assert csv_file[-1] == 'DOB1,2024-08-01 00:30:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
 
 
 @pytest.mark.anyio
@@ -3463,8 +3482,8 @@ async def test_download_station_data_both_dates_set(
 
     # 11 data points + 1 header
     assert len(csv_file) == 6
-    assert csv_file[1] == 'DOB1,2024-08-01 00:10:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
-    assert csv_file[-1] == 'DOB1,2024-08-01 00:30:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
+    assert csv_file[1] == 'DOB1,2024-08-01 00:10:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
+    assert csv_file[-1] == 'DOB1,2024-08-01 00:30:00+00:00,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,35.5,,,,,,,,,,,True'  # noqa: E501
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
supersedes https://github.com/RUBclim/d2r-api/pull/77 and is the 4th part as mentioned here: https://github.com/RUBclim/d2r-api/pull/77#issuecomment-2913454567

This needs #85 to be merged first for the tests to succeed.

This exposes the result of the buddy check via the public API for `/data` and the csv-based file download.