### PR TITLE
add override path to raster lifecycle manager

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -112,7 +112,10 @@ def setup_periodic_tasks(
     )
     sender.add_periodic_task(
         crontab(minute='34', hour='*/1'),
-        apply_raster_lifecycle.s(days=int(os.environ['RASTER_LIFECYCLE_DAYS'])),
+        apply_raster_lifecycle.s(
+            days=int(os.environ['RASTER_LIFECYCLE_DAYS']),
+            override_path='/usr/src/app/rasters/',
+        ),
         name='apply-raster-lifecycle-periodic',
         expires=60*60,
     )


### PR DESCRIPTION
this is a bit unfortunate that the paths are inconsistent and should be fixed in an additional step